### PR TITLE
Feature/separate signing functions

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="/usr/local/Cellar/gradle/6.5.1/libexec" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 group 'nl.uncinc.androidci'
-version '0.3'
-sourceCompatibility = 1.8
+version '0.4'
+sourceCompatibility = 1.11
 
 repositories {
     mavenCentral()
@@ -26,7 +26,7 @@ gradlePlugin {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile "com.android.tools.build:gradle:3.5.3"
+    compile "com.android.tools.build:gradle:7.4.0"
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/src/main/groovy/nl/uncinc/androidci/UncIncAndroidCIPlugin.groovy
+++ b/src/main/groovy/nl/uncinc/androidci/UncIncAndroidCIPlugin.groovy
@@ -1,6 +1,7 @@
 package nl.uncinc.androidci
 
-import com.android.build.gradle.internal.dsl.SigningConfig
+import com.android.build.api.variant.impl.SigningConfigImpl
+import com.android.builder.model.SigningConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -68,12 +69,28 @@ class UncIncAndroidCIPlugin implements Plugin<Project> {
     }
 
     SigningConfig getSigningConfig() {
-        def signingConfig = new SigningConfig("CIStore")
+        def signingConfig = new SigningConfigImpl("CIStore")
         signingConfig.storeFile = project.file(androidci.keystoreProperties['storeFile'])
         signingConfig.storePassword = androidci.keystoreProperties['storePassword']
         signingConfig.keyAlias = androidci.keystoreProperties['keyAlias']
         signingConfig.keyPassword = androidci.keystoreProperties['keyPassword']
         return signingConfig
+    }
+
+    File getStoreFile() {
+        return project.file(androidci.keystoreProperties['storeFile'])
+    }
+
+    String getStorePassword() {
+        return androidci.keystoreProperties['storePassword']
+    }
+
+    String getKeyAlias() {
+        return androidci.keystoreProperties['keyAlias']
+    }
+
+    String getKeyPassword() {
+        return androidci.keystoreProperties['keyPassword']
     }
 
     String getGitHash() {


### PR DESCRIPTION
Due to an update of gradle, the SigningConfig class structure has changed, which makes it incompatible with our current build setup. This PR separates the functions, making the gradle config a lot simpler.